### PR TITLE
byteOffset defaults as buf.byteOffset rather than 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ exports.encode = function encode (bu, buf, byteOffset) {
 exports.encode.bytes = 0
 
 exports.decode = function decode (buf, byteOffset, byteLength) {
-  if (!byteOffset) byteOffset = 0
+  if (!byteOffset) byteOffset = buf.byteOffset
   if (!byteLength) byteLength = buf.byteLength
 
   assert(buf.buffer)

--- a/test.js
+++ b/test.js
@@ -10,6 +10,8 @@ test('Simple tests', function (assert) {
   assert.same(codec.decode.bytes, 7)
   assert.same(0xffffffffn, codec.decode(Buffer.alloc(4, 0xff)))
   assert.same(codec.decode.bytes, 4)
+  assert.same(0xffffffffn, codec.decode(Buffer.from('ffffffff', 'hex')))
+  assert.same(codec.decode.bytes, 4)
 
   var buf = Buffer.alloc(5)
   assert.same(buf, codec.encode(0xffffffffn, buf))


### PR DESCRIPTION
`decode(Buffer.from('04ffffffff', 'hex'))` returns the decoding of the first 5 bytes of `buf.buffer`, which is the page on which the test buffer is located, rather than the buffer itself.

To fix this, `byteOffset` should take `buf.byteOffset` as its default value.